### PR TITLE
Classes generation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ In order to generate Kotlin code from your tracking event definitions, you first
 
 ```kotlin
 val generateAnalyticsEvents by tasks.registering(com.deliveryhero.litics.EventsGeneratorTask::class) {
+
+    // Platform type used to apply platform dependant behavior for the generated files.
+    platform = Platform.ANDROID
+    
     // Package name used for the generated files.
     packageName = "com.example.analytics"
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ In order to generate Kotlin code from your tracking event definitions, you first
 val generateAnalyticsEvents by tasks.registering(com.deliveryhero.litics.EventsGeneratorTask::class) {
 
     // Platform type used to apply platform dependant behavior for the generated files.
-    platform = Platform.ANDROID
+    platform = Platform.JS
     
     // Package name used for the generated files.
     packageName = "com.example.analytics"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Litics allows you to have a single source of tracking event definitions, which c
 The Litics API contains classes that are required by the generated code.
 
 ```kotlin
-implementation("com.deliveryhero.litics:litics:0.1.1")
+implementation("com.deliveryhero.litics:litics:0.1.2")
 ```
 
 The Litics Gradle task takes your event definitions and generates Kotlin code.
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.github.deliveryhero.litics:litics-gradle-task:0.1.1")
+        classpath("com.github.deliveryhero.litics:litics-gradle-task:0.1.2")
     }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 GROUP=com.deliveryhero.litics
-VERSION_NAME=0.1.1
+VERSION_NAME=0.1.2
 
 POM_INCEPTION_YEAR=2021
 POM_URL=https://github.com/deliveryhero/litics/

--- a/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGenerator.kt
+++ b/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGenerator.kt
@@ -1,26 +1,13 @@
 package com.deliveryhero.litics
 
 import com.charleskorn.kaml.Yaml
-import com.squareup.kotlinpoet.ARRAY
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.MemberName
-import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.STRING
-import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.buildCodeBlock
-import com.squareup.kotlinpoet.joinToCode
-import java.io.File
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.io.File
 
 private const val PACKAGE_LITICS = "com.deliveryhero.litics"
 
@@ -91,7 +78,6 @@ object EventsGenerator {
         val funSpecs = buildFunSpecs(eventDefinitions)
 
         val interfaceTypeSpec = with(TypeSpec.classBuilder(generatedEventAnalyticsAbstractClass)) {
-            this.
             addModifiers(ABSTRACT)
             if (platform == Platform.JS) {
                 addAnnotation(ClassName("kotlin.js", "JsExport"))

--- a/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
+++ b/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
@@ -3,12 +3,20 @@ package com.deliveryhero.litics
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+@Suppress("unused")
+enum class Platform {
+    ANDROID,
+    JS,
+}
+
 abstract class EventsGeneratorTask : DefaultTask() {
+
+    @Input
+    lateinit var platform: Platform
 
     @Input
     lateinit var packageName: String
@@ -20,5 +28,5 @@ abstract class EventsGeneratorTask : DefaultTask() {
     lateinit var targetDirectory: File
 
     @TaskAction
-    fun generate() = EventsGenerator.generate(packageName, sourceFile, targetDirectory)
+    fun generate() = EventsGenerator.generate(platform, packageName, sourceFile, targetDirectory)
 }

--- a/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
+++ b/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
@@ -1,14 +1,14 @@
 package com.deliveryhero.litics
 
-import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
-@Suppress("unused")
 enum class Platform {
+    @Suppress("unused")
     JVM,
     JS,
 }

--- a/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
+++ b/litics-gradle-task/src/main/kotlin/com/deliveryhero/litics/EventsGeneratorTask.kt
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.TaskAction
 
 @Suppress("unused")
 enum class Platform {
-    ANDROID,
+    JVM,
     JS,
 }
 


### PR DESCRIPTION
`In draft until testing and publishing approach is clarified`

#### Motivation

During Kotlin update from `1.6.20` to `1.9.20` in Pelican Android project we encountered an issue with unresolved `@JsExport` annotations in generated files.

#### Changes
 - `@JsExport` annotation is added only for JS platform
 - `EventsGeneratorTask` has one more input parameter to specify the client platform
 - Lib version is updated to `0.1.2`